### PR TITLE
Dockerfile-Ubuntu-20.04: Add libssl-dev, bc, lzop

### DIFF
--- a/Dockerfile-Ubuntu-20.04
+++ b/Dockerfile-Ubuntu-20.04
@@ -9,7 +9,8 @@ RUN apt update
 RUN apt install -y gawk wget git-core diffstat unzip texinfo \
     gcc-multilib build-essential chrpath socat cpio python python3 \
     python3-pip python3-pexpect xz-utils debianutils iputils-ping \
-    libsdl1.2-dev xterm tar locales net-tools rsync sudo vim curl zstd liblz4-tool
+    libsdl1.2-dev xterm tar locales net-tools rsync sudo vim curl zstd \
+    liblz4-tool libssl-dev bc lzop
 
 # Set up locales
 RUN locale-gen en_US.UTF-8 && \


### PR DESCRIPTION
Add dependencies required to build kernel out-of-tree with Yocto sdk (required as of 5.15.72-2.2.0, cortexa9)