### PR TITLE
manifest hosting moved from codeaurora to github

### DIFF
--- a/imx-5.10.35-2.0.0/env.sh
+++ b/imx-5.10.35-2.0.0/env.sh
@@ -17,6 +17,6 @@ MACHINE="imx8mnevk"
 DISTRO="fsl-imx-xwayland"
 IMAGES="imx-image-core"
 
-REMOTE="https://source.codeaurora.org/external/imx/imx-manifest"
+REMOTE="https://github.com/nxp-imx/imx-manifest"
 BRANCH="imx-linux-hardknott"
 MANIFEST=${IMX_RELEASE}".xml"

--- a/imx-5.10.52-2.1.0/env.sh
+++ b/imx-5.10.52-2.1.0/env.sh
@@ -17,6 +17,6 @@ MACHINE="imx8mnevk"
 DISTRO="fsl-imx-xwayland"
 IMAGES="imx-image-core"
 
-REMOTE="https://source.codeaurora.org/external/imx/imx-manifest"
+REMOTE="https://github.com/nxp-imx/imx-manifest"
 BRANCH="imx-linux-hardknott"
 MANIFEST=${IMX_RELEASE}".xml"

--- a/imx-5.10.72-2.2.0/env.sh
+++ b/imx-5.10.72-2.2.0/env.sh
@@ -17,6 +17,6 @@ MACHINE="imx8mpevk"
 DISTRO="fsl-imx-xwayland"
 IMAGES="imx-image-core"
 
-REMOTE="https://source.codeaurora.org/external/imx/imx-manifest"
+REMOTE="https://github.com/nxp-imx/imx-manifest"
 BRANCH="imx-linux-hardknott"
 MANIFEST=${IMX_RELEASE}".xml"

--- a/imx-5.15.32-2.0.0/env.sh
+++ b/imx-5.15.32-2.0.0/env.sh
@@ -17,6 +17,6 @@ MACHINE="imx8mpevk"
 DISTRO="fsl-imx-xwayland"
 IMAGES="imx-image-core"
 
-REMOTE="https://source.codeaurora.org/external/imx/imx-manifest"
+REMOTE="https://github.com/nxp-imx/imx-manifest"
 BRANCH="imx-linux-kirkstone"
 MANIFEST=${IMX_RELEASE}".xml"

--- a/imx-5.15.5-1.0.0/env.sh
+++ b/imx-5.15.5-1.0.0/env.sh
@@ -17,6 +17,6 @@ MACHINE="imx8mpevk"
 DISTRO="fsl-imx-xwayland"
 IMAGES="imx-image-core"
 
-REMOTE="https://source.codeaurora.org/external/imx/imx-manifest"
+REMOTE="https://github.com/nxp-imx/imx-manifest"
 BRANCH="imx-linux-honister"
 MANIFEST=${IMX_RELEASE}".xml"

--- a/imx-5.15.52-2.1.0/env.sh
+++ b/imx-5.15.52-2.1.0/env.sh
@@ -17,6 +17,6 @@ MACHINE="imx8mpevk"
 DISTRO="fsl-imx-xwayland"
 IMAGES="imx-image-core"
 
-REMOTE="https://source.codeaurora.org/external/imx/imx-manifest"
+REMOTE="https://github.com/nxp-imx/imx-manifest"
 BRANCH="imx-linux-kirkstone"
 MANIFEST=${IMX_RELEASE}".xml"


### PR DESCRIPTION
NXP has abandoned Codeaurora, see https://bye.codeaurora.org/, this PR fixes that.