### PR TITLE
Fix errors running imx-docker 

### DIFF
--- a/Dockerfile-Ubuntu-20.04
+++ b/Dockerfile-Ubuntu-20.04
@@ -26,6 +26,10 @@ RUN rm /bin/sh && ln -s bash /bin/sh
 ADD https://storage.googleapis.com/git-repo-downloads/repo /usr/local/bin/
 RUN chmod 755 /usr/local/bin/repo
 
+# Correct Python path
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
+RUN update-alternatives --config python
+
 # Add your user to sudoers to be able to install other packages in the container.
 ARG USER
 RUN echo "${USER} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/${USER} && \

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -23,6 +23,7 @@ if [ $# -ne 1 ]
                      --build-arg "USER=$(whoami)" \
                      --build-arg "host_uid=$(id -u)" \
                      --build-arg "host_gid=$(id -g)" \
+					 --network host \
                      -f $1 \
                      .
 fi


### PR DESCRIPTION
Add correct python path to Dockerfile to avoid build error, change docker container to use host network to avoid build-time network issues. Required to complete build on Win10 / WSL2.
