### PR TITLE
Update Dockerfile-Ubuntu-22.04

### DIFF
--- a/Dockerfile-Ubuntu-22.04
+++ b/Dockerfile-Ubuntu-22.04
@@ -7,7 +7,7 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update
 RUN apt install -y gawk wget git-core diffstat unzip texinfo \
-    gcc-multilib build-essential chrpath socat cpio python python3 \
+    gcc-multilib build-essential chrpath socat cpio python3 \
     python3-pip python3-pexpect xz-utils debianutils iputils-ping \
     libsdl1.2-dev xterm tar locales net-tools rsync sudo vim curl zstd \
     liblz4-tool libssl-dev bc lzop libgnutls28-dev efitools git-lfs


### PR DESCRIPTION
remove apt install package 'python' as it does not exist by that name any longer and throws an error