### PR TITLE
Dockerfiles add screen for devshell

### DIFF
--- a/Dockerfile-Ubuntu-18.04
+++ b/Dockerfile-Ubuntu-18.04
@@ -9,7 +9,7 @@ RUN apt update
 RUN apt install -y gawk wget git-core diffstat unzip texinfo \
     gcc-multilib build-essential chrpath socat cpio python python3 \
     python3-pip python3-pexpect xz-utils debianutils iputils-ping \
-    libsdl1.2-dev xterm tar locales net-tools rsync sudo vim curl
+    libsdl1.2-dev xterm tar locales net-tools rsync sudo vim curl screen
 
 # Set up locales
 RUN locale-gen en_US.UTF-8 && \

--- a/Dockerfile-Ubuntu-20.04
+++ b/Dockerfile-Ubuntu-20.04
@@ -10,7 +10,7 @@ RUN apt install -y gawk wget git-core diffstat unzip texinfo \
     gcc-multilib build-essential chrpath socat cpio python python3 \
     python3-pip python3-pexpect xz-utils debianutils iputils-ping \
     libsdl1.2-dev xterm tar locales net-tools rsync sudo vim curl zstd \
-    liblz4-tool libssl-dev bc lzop
+    liblz4-tool libssl-dev bc lzop screen
 
 # Set up locales
 RUN locale-gen en_US.UTF-8 && \

--- a/Dockerfile-Ubuntu-22.04
+++ b/Dockerfile-Ubuntu-22.04
@@ -10,7 +10,7 @@ RUN apt install -y gawk wget git-core diffstat unzip texinfo \
     gcc-multilib build-essential chrpath socat file cpio python3 \
     python3-pip python3-pexpect xz-utils debianutils iputils-ping \
     libsdl1.2-dev xterm tar locales net-tools rsync sudo vim curl zstd \
-    liblz4-tool libssl-dev bc lzop libgnutls28-dev efitools git-lfs
+    liblz4-tool libssl-dev bc lzop libgnutls28-dev efitools git-lfs screen
 
 # Set up locales
 RUN locale-gen en_US.UTF-8 && \


### PR DESCRIPTION
While trying to run devshell (`bitbake -c devshell virtual/kernel`) got error:
```
NOTE: Executing Tasks
ERROR: linux-imx-6.6.3+git-r0 do_devshell: No valid terminal found, unable to open devshell.
Tried the following commands:
	tmux split-window -c "{cwd}" "do_terminal"
	tmux new-window -c "{cwd}" -n "OpenEmbedded Developer Shell" "do_terminal"
	xfce4-terminal -T "OpenEmbedded Developer Shell" -e "do_terminal"
	terminology -T="OpenEmbedded Developer Shell" -e do_terminal
	mate-terminal --disable-factory -t "OpenEmbedded Developer Shell" -x do_terminal
	konsole --separate --workdir . -p tabtitle="OpenEmbedded Developer Shell" -e do_terminal
	gnome-terminal -t "OpenEmbedded Developer Shell" -- do_terminal
	xterm -T "OpenEmbedded Developer Shell" -e do_terminal
	urxvt -T "OpenEmbedded Developer Shell" -e do_terminal
	rxvt -T "OpenEmbedded Developer Shell" -e do_terminal
	tmux new -c "{cwd}" -d -s devshell -n devshell "do_terminal"
	screen -D -m -t "OpenEmbedded Developer Shell" -S devshell do_terminal
ERROR: Logfile of failure stored in: /opt/yocto/imx-6.6.3-1.0.0-build/build_fsl-imx-wayland/tmp/work/imx93evk-poky-linux/linux-imx/6.6.3+git/temp/log.do_devshell.875
ERROR: Task (/opt/yocto/imx-6.6.3-1.0.0-build/sources/meta-imx/meta-imx-bsp/recipes-kernel/linux/linux-imx_6.6.bb:do_devshell) failed with exit code '1'
```

TMUX and Screen are the two applicaple options in that order of priority. I chose screen out of preference, however, tmux could also be used. This fixes devshell access (the ordinary `^A+D` to detach etc.)