### PR TITLE
Update Dockerfile-Ubuntu-22.04

### DIFF
--- a/Dockerfile-Ubuntu-22.04
+++ b/Dockerfile-Ubuntu-22.04
@@ -28,8 +28,8 @@ RUN chmod 755 /usr/local/bin/repo
 
 # Add your user to sudoers to be able to install other packages in the container.
 ARG USER
-RUN echo "${USER} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/${USER} && \
-    chmod 0440 /etc/sudoers.d/${USER}
+RUN echo "${USER} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/yocto_user && \
+    chmod 0440 /etc/sudoers.d/yocto_user
 
 # Set the arguments for host_id and user_id to be able to save the build artifacts
 # outside the container, on host directories, as docker volumes.


### PR DESCRIPTION
Only files in the /etc/sudoers.d directory that do not end with '~' or contain a '.' character will be parsed. Consequently, a user named a.einstein was unable to build the Yocto image.