### PR TITLE
Improved the container user creation process

### DIFF
--- a/Dockerfile-Ubuntu-18.04
+++ b/Dockerfile-Ubuntu-18.04
@@ -34,8 +34,11 @@ RUN echo "${USER} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/${USER} && \
 # outside the container, on host directories, as docker volumes.
 ARG host_uid \
     host_gid
-RUN groupadd -g $host_gid nxp && \
-    useradd -g $host_gid -m -s /bin/bash -u $host_uid $USER
+
+COPY create-container-user.sh /
+RUN chmod +x /create-container-user.sh && \
+	/create-container-user.sh ${host_uid} ${host_gid} ${USER} && \
+	rm /create-container-user.sh
 
 # Yocto builds should run as a normal user.
 USER $USER

--- a/Dockerfile-Ubuntu-20.04
+++ b/Dockerfile-Ubuntu-20.04
@@ -35,8 +35,11 @@ RUN echo "${USER} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/${USER} && \
 # outside the container, on host directories, as docker volumes.
 ARG host_uid \
     host_gid
-RUN groupadd -g $host_gid nxp && \
-    useradd -g $host_gid -m -s /bin/bash -u $host_uid $USER
+
+COPY create-container-user.sh /
+RUN chmod +x /create-container-user.sh && \
+	/create-container-user.sh ${host_uid} ${host_gid} ${USER} && \
+	rm /create-container-user.sh
 
 # Yocto builds should run as a normal user.
 USER $USER

--- a/Dockerfile-Ubuntu-22.04
+++ b/Dockerfile-Ubuntu-22.04
@@ -35,8 +35,11 @@ RUN echo "${USER} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/${USER} && \
 # outside the container, on host directories, as docker volumes.
 ARG host_uid \
     host_gid
-RUN groupadd -g $host_gid nxp && \
-    useradd -g $host_gid -m -s /bin/bash -u $host_uid $USER
+
+COPY create-container-user.sh /
+RUN chmod +x /create-container-user.sh && \
+	/create-container-user.sh ${host_uid} ${host_gid} ${USER} && \
+	rm /create-container-user.sh
 
 # Yocto builds should run as a normal user.
 USER $USER

--- a/Dockerfile-Ubuntu-24.04
+++ b/Dockerfile-Ubuntu-24.04
@@ -35,8 +35,11 @@ RUN echo "${USER} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/${USER} && \
 # outside the container, on host directories, as docker volumes.
 ARG host_uid \
     host_gid
-RUN groupadd -g $host_gid nxp && \
-    useradd -g $host_gid -m -s /bin/bash -u $host_uid $USER
+
+COPY create-container-user.sh /
+RUN chmod +x /create-container-user.sh && \
+	/create-container-user.sh ${host_uid} ${host_gid} ${USER} && \
+	rm /create-container-user.sh
 
 # Yocto builds should run as a normal user.
 USER $USER

--- a/create-container-user.sh
+++ b/create-container-user.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -e
+
+HOST_UID="$1"
+HOST_GID="$2"
+USER_NAME="$3"
+
+# Ensure group exists with desired GID and name
+if ! getent group "${HOST_GID}" >/dev/null; then
+    groupadd -g "${HOST_GID}" "${USER_NAME}"
+else
+    existing_group="$(getent group "${HOST_GID}" | cut -d: -f1)"
+    if [ "${existing_group}" != "${USER_NAME}" ]; then
+        groupmod -n "${USER_NAME}" "${existing_group}"
+    fi
+fi
+
+# Ensure user exists with desired UID and name
+if ! getent passwd "${HOST_UID}" >/dev/null; then
+    useradd \
+        -u "${HOST_UID}" \
+        -g "${HOST_GID}" \
+        -m \
+        -s /bin/bash \
+        "${USER_NAME}"
+else
+    existing_user="$(getent passwd "${HOST_UID}" | cut -d: -f1)"
+    if [ "${existing_user}" != "${USER_NAME}" ]; then
+        usermod -l "${USER_NAME}" "${existing_user}"
+        usermod -d "/home/${USER_NAME}" -m "${USER_NAME}"
+    fi
+fi


### PR DESCRIPTION
This accounts for the condition where the UID and/or GID of the host system user already exists in the container. This was causing the `docker build` to fail late in the process, not _quite_ completing the container build.

A new `create-container-user.sh` script has a slightly more nuanced user creation heuristic that _creates_ the new host user/group if there is no UID/GID overlap and _modifies_ the existing user/group if there _is._ The script is shared with _all_ dockerfiles and frankly looks a lot nicer than it would if it was included in each with all those line continuation escapes and semicolons.